### PR TITLE
chore(frontend): weekly shadcn component update

### DIFF
--- a/frontend/omni/package.json
+++ b/frontend/omni/package.json
@@ -28,7 +28,7 @@
   "devDependencies": {
     "@biomejs/biome": "^2.4.10",
     "@internationalized/date": "^3.12.0",
-    "@lucide/svelte": "^1.7.0",
+    "@lucide/svelte": "^1.8.0",
     "@sveltejs/vite-plugin-svelte": "^7.0.0",
     "@tailwindcss/vite": "^4.2.2",
     "bits-ui": "^2.17.2",

--- a/frontend/omni/pnpm-lock.yaml
+++ b/frontend/omni/pnpm-lock.yaml
@@ -52,8 +52,8 @@ importers:
         specifier: ^3.12.0
         version: 3.12.0
       '@lucide/svelte':
-        specifier: ^1.7.0
-        version: 1.7.0(svelte@5.55.1)
+        specifier: ^1.8.0
+        version: 1.8.0(svelte@5.55.1)
       '@sveltejs/vite-plugin-svelte':
         specifier: ^7.0.0
         version: 7.0.0(svelte@5.55.1)(vite@8.0.5(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.2)(jiti@2.6.1))
@@ -206,8 +206,8 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
-  '@lucide/svelte@1.7.0':
-    resolution: {integrity: sha512-YytBKOUBGox7yWcykZnYxOkn5WpR5G1qYXLYXV/j1B79SOTTEKzB+s5yF5Rq9l9OkweDStNH2b4yTqfvhEhV8g==}
+  '@lucide/svelte@1.8.0':
+    resolution: {integrity: sha512-+zYQUKqEOVP5lxbGmxL1OVgGMQtRK91eIJ0bR+3Cr1ts4oQEsQfxyzzd5X47psJlblAuGFrl2xm4YuATjR9oaA==}
     peerDependencies:
       svelte: ^5
 
@@ -1069,7 +1069,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@lucide/svelte@1.7.0(svelte@5.55.1)':
+  '@lucide/svelte@1.8.0(svelte@5.55.1)':
     dependencies:
       svelte: 5.55.1
 


### PR DESCRIPTION
Automated weekly update of shadcn-svelte components via `update-shadcn.sh`.