### PR TITLE
chore(frontend): weekly shadcn component update

### DIFF
--- a/frontend/omni/package.json
+++ b/frontend/omni/package.json
@@ -31,7 +31,7 @@
   "devDependencies": {
     "@biomejs/biome": "^2.4.15",
     "@internationalized/date": "^3.12.1",
-    "@lucide/svelte": "^1.14.0",
+    "@lucide/svelte": "^1.16.0",
     "@sveltejs/vite-plugin-svelte": "^7.1.2",
     "@tailwindcss/vite": "^4.3.0",
     "bits-ui": "^2.18.1",

--- a/frontend/omni/pnpm-lock.yaml
+++ b/frontend/omni/pnpm-lock.yaml
@@ -61,8 +61,8 @@ importers:
         specifier: ^3.12.1
         version: 3.12.1
       '@lucide/svelte':
-        specifier: ^1.14.0
-        version: 1.14.0(svelte@5.55.5(@typescript-eslint/types@8.57.2))
+        specifier: ^1.16.0
+        version: 1.16.0(svelte@5.55.5(@typescript-eslint/types@8.57.2))
       '@sveltejs/vite-plugin-svelte':
         specifier: ^7.1.2
         version: 7.1.2(svelte@5.55.5(@typescript-eslint/types@8.57.2))(vite@8.0.12(@types/node@25.6.0)(jiti@2.7.0))
@@ -219,8 +219,8 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
-  '@lucide/svelte@1.14.0':
-    resolution: {integrity: sha512-MVuP5VRCBQa2OaIpaRbuEV4k5OV2dy9MyxA6Tf4Sz/IN0v3zzUU72ObHc9r2Zn/wSMXDg6lLrHrczqI7w7gCzQ==}
+  '@lucide/svelte@1.16.0':
+    resolution: {integrity: sha512-AvvPJnaWxeiNkAljI5MsSEc84yHPLMaWQIAJOcbX7k9au/f9ITS7cxTTQiautDiOFKVOXiYdZ+d6mtl88J+Kbg==}
     peerDependencies:
       svelte: ^5
 
@@ -1137,7 +1137,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@lucide/svelte@1.14.0(svelte@5.55.5(@typescript-eslint/types@8.57.2))':
+  '@lucide/svelte@1.16.0(svelte@5.55.5(@typescript-eslint/types@8.57.2))':
     dependencies:
       svelte: 5.55.5(@typescript-eslint/types@8.57.2)
 


### PR DESCRIPTION
Automated weekly update of shadcn-svelte components via `update-shadcn.sh`.